### PR TITLE
Changed default target to main instead of local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: local
+default: main
 
 install:
 	cd build && pipenv install

--- a/USAGE.md
+++ b/USAGE.md
@@ -6,7 +6,7 @@ The CLI for the AAA-py is (for now) based on Make and pipenv.
 
 To setup the dependencies properly, make sure that the Python and git2 development headers are available in your `PATH`.
 
-One this is done, simply run `make main`, and the website will be available at http://localhost:8080once building is completed (provided the 8080 port is available for the spawned server).
+One this is done, simply run `make`, and the website will be available at http://localhost:8080once building is completed (provided the 8080 port is available for the spawned server).
 
 ## Advanced setup
 
@@ -21,6 +21,4 @@ One this is done, simply run `make main`, and the website will be available at h
 ## Additional build target
 
 1. `local`: `make local` will run the `build_local` and `serve` targets.
-It is currently the default target for development convenience.
-This is subject to later change.
-Do **NOT** use `make` or `make local` at first use, since this `build_local` requires that the contents are already presents.
+Do **NOT** use `make local` at first use, since this `build_local` requires that the contents are already presents.


### PR DESCRIPTION
To ensure we preferably use the latest upstream from the AAA, I made `main` the default `make` target.
Currently, `local` was the default target, which didn't fetch the latest changes and used the files already present in the filesystem.
The change was also reflected in the documentation (`USAGE.md`)